### PR TITLE
Fix build/run warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # MongodDB URI
-MONGODB_URI=mongodb://localhost:27017
+MONGODB_URI=mongodb://localhost:27017/overlord
 
 # Token needed for /signup
 SIGNUP_TOKEN=asdf

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "body-parser": "^1.15.2",
     "compression": "^1.6.2",
     "concurrently": "^3.4.0",
-    "connect-mongo": "^1.3.2",
+    "connect-mongo": "^2.0.0",
     "dotenv": "^2.0.0",
     "errorhandler": "^1.4.3",
     "express": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "npm run build && npm run watch",
     "build": "npm run build-ts && npm run tslint",
     "postinstall": "npm run build",
-    "serve": "nodemon dist/server.js",
+    "serve": "nodemon dist/server.js --delay 0.1",
     "serve-prod": "node dist/server.js",
     "watch": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run serve\"",
     "test": "jest --forceExit",
@@ -87,7 +87,7 @@
     "typescript": "^2.4.0"
   },
   "devDependencies": {
-    "nodemon": "^1.11.0"
+    "nodemon": "^1.14.3"
   },
   "false": {}
 }

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -33,7 +33,7 @@ import {
 
 const userCtrl: UserActions = new UserActionsImpl()
 const cvCtrl: CVActions = new CVActionsImpl()
-const UNAUTHORIZED_ERROR = Promise.reject('not authorized')
+const UNAUTHORIZED_ERROR = 'not authorized'
 const feedbackCtrl: FeedbackActions = new FeedbackActionsImpl()
 
 const schema = new GraphQLSchema({
@@ -46,7 +46,7 @@ const schema = new GraphQLSchema({
         resolve(a, b, { req }) {
           return req.isAuthenticated()
             ? req.user
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       users: {
@@ -58,7 +58,7 @@ const schema = new GraphQLSchema({
         resolve(a, { memberType }, { req }) {
           return req.isAuthenticated()
             ? userCtrl.getUsers(memberType)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       feedback: {
@@ -70,7 +70,7 @@ const schema = new GraphQLSchema({
         resolve(a, { companyId }, { req }) {
           return req.isAuthenticated()
             ? feedbackCtrl.getFeedback(companyId)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       allFeedback: {
@@ -79,7 +79,7 @@ const schema = new GraphQLSchema({
         resolve(a, b, { req }) {
           return req.isAuthenticated()
             ? feedbackCtrl.getAllFeedback()
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
     },
@@ -96,7 +96,7 @@ const schema = new GraphQLSchema({
         resolve(a, { fields }, { req }) {
           return req.isAuthenticated()
             ? userCtrl.updateUserProfile(req.user.id, fields)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       updateCV: {
@@ -108,7 +108,7 @@ const schema = new GraphQLSchema({
         resolve(a, { fields }, { req }) {
           return req.isAuthenticated()
             ? cvCtrl.updateCV(req.user.id, fields)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       createFeedback: {
@@ -120,7 +120,7 @@ const schema = new GraphQLSchema({
         resolve(a, { companyId }, { req }) {
           return req.isAuthenticated()
             ? feedbackCtrl.createFeedback(companyId)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       updateFeedback: {
@@ -133,7 +133,7 @@ const schema = new GraphQLSchema({
         resolve(a, { companyId, fields }, { req }) {
           return req.isAuthenticated()
             ? feedbackCtrl.updateFeedback(companyId, fields)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
       removeFeedback: {
@@ -146,7 +146,7 @@ const schema = new GraphQLSchema({
         resolve(a, { companyId }, { req }) {
           return req.isAuthenticated()
             ? feedbackCtrl.removeFeedback(companyId)
-            : UNAUTHORIZED_ERROR
+            : Promise.reject(UNAUTHORIZED_ERROR)
         },
       },
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,6 @@ const MongoStore = mongo(session)
  * Load environment variables from .env file, where API
  * keys and passwords are configured.
  */
-
 dotenv.config()
 
 /**
@@ -47,6 +46,7 @@ const app = express()
  */
 const options = {
   promiseLibrary: global.Promise,
+  useMongoClient: true,
 }
 
 mongoose.connect(process.env.MONGODB_URI, options)

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,10 +755,6 @@ es6-promise@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.2.1.tgz#ec56233868032909207170c39448e24449dd1fc4"
 
-es6-promise@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
-
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -1445,72 +1441,6 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._bindcallback@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._createassigner@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz#838a5bae2fdaca63ac22dee8e19fa4e6d6970b11"
-  dependencies:
-    lodash._bindcallback "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
-    lodash.restparam "^3.0.0"
-
-lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-
-lodash.assign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-3.2.0.tgz#3ce9f0234b4b2223e296b8fa0ac1fee8ebca64fa"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._createassigner "^3.0.0"
-    lodash.keys "^3.0.0"
-
-lodash.defaults@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-3.1.2.tgz#c7308b18dbf8bc9372d701a73493c61192bd2e2c"
-  dependencies:
-    lodash.assign "^3.0.0"
-    lodash.restparam "^3.0.0"
-
-lodash.isarguments@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
-
-lodash.isarray@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.keys@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
-  dependencies:
-    lodash._getnative "^3.0.0"
-    lodash.isarguments "^3.0.0"
-    lodash.isarray "^3.0.0"
-
-lodash.restparam@^3.0.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
 lodash@^4.14.0, lodash@^4.16.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -1700,20 +1630,18 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-nodemon@^1.11.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.12.1.tgz#996a56dc49d9f16bbf1b78a4de08f13634b3878d"
+nodemon@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.14.3.tgz#f08d66726fb9876d76956b57cc91624793de4dbb"
   dependencies:
     chokidar "^1.7.0"
     debug "^2.6.8"
-    es6-promise "^3.3.1"
     ignore-by-default "^1.0.1"
-    lodash.defaults "^3.1.2"
     minimatch "^3.0.4"
-    ps-tree "^1.1.0"
+    pstree.remy "^1.1.0"
     touch "^3.1.0"
     undefsafe "0.0.3"
-    update-notifier "^2.2.0"
+    update-notifier "^2.3.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -1912,6 +1840,12 @@ ps-tree@^1.1.0:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pstree.remy@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
+  dependencies:
+    ps-tree "^1.1.0"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -2438,7 +2372,7 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-update-notifier@^2.2.0:
+update-notifier@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.3.0.tgz#4e8827a6bb915140ab093559d7014e3ebb837451"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,7 +380,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.0, bluebird@^3.4.0, bluebird@^3.5.0:
+bluebird@^3.4.0, bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -608,12 +608,11 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
-connect-mongo@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/connect-mongo/-/connect-mongo-1.3.2.tgz#7cbf58dfff26760e5e00e017d0a85b4bc90b9d37"
+connect-mongo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/connect-mongo/-/connect-mongo-2.0.0.tgz#3e4d036a6869385b0191a3737d3051a86abc2fb8"
   dependencies:
-    bluebird "^3.0"
-    mongodb ">= 1.2.0 <3.0.0"
+    mongodb "^2.0.36"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -1618,7 +1617,7 @@ mongodb-core@2.1.17:
     bson "~1.0.4"
     require_optional "~1.0.0"
 
-mongodb@2.2.33, "mongodb@>= 1.2.0 <3.0.0":
+mongodb@2.2.33, mongodb@^2.0.36:
   version "2.2.33"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.33.tgz#b537c471d34a6651b48f36fdbf29750340e08b50"
   dependencies:


### PR DESCRIPTION
Fixes some warnings happening on build
* Use new mongoose connection logic, old one is deprecated resulting in an error
    * The new one defaults to db 'admin' instead of 'test. Updated .env to use 'overlord' by default.
* Update connect-mongo, old one used used deprecated methods resulting in errors
* The `UNATHORIZED_ERROR` var in schema.ts were thrown when it was declared which resulted in an "Unhandled Promise Rejection" warning. Changed to reject promises where they happen.
* Update nodemon and add delay before rebuild. Nodemon previously restarted multiple times for each recompilation.