### PR TITLE
Event check-ins

### DIFF
--- a/src/controllers/EventActions.ts
+++ b/src/controllers/EventActions.ts
@@ -1,4 +1,4 @@
-import { Event, User } from '../models'
+import { Event, EventCheckIn, User } from '../models'
 
 export interface EventActions {
 
@@ -14,5 +14,16 @@ export interface EventActions {
 
   // Remove an event with the given id
   removeEvent(id: string): Promise<boolean>
+
+  // Gets all check-ins for the event with the given id
+  getCheckIns(auth: User, eventId: string): Promise<EventCheckIn[]>
+
+  // Add a check-in for a user to the event with the given id
+  addCheckIn(auth: User, eventId: string, userId: string):
+    Promise<EventCheckIn>
+
+  // Removes a check-in for a user to the event with the given id
+  removeCheckIn(auth: User, eventId: string, userId: string):
+    Promise<EventCheckIn>
 
 }

--- a/src/graphql/GraphQLEventCheckIn.ts
+++ b/src/graphql/GraphQLEventCheckIn.ts
@@ -1,0 +1,13 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql'
+
+export const EventCheckInType = new GraphQLObjectType({
+  name : 'EventCheckIn',
+  fields : {
+    userId: { type: GraphQLString },
+    checkedInAt: { type: GraphQLString },
+    checkedInById: { type: GraphQLString },
+  },
+})

--- a/src/graphql/GraphQLUser.ts
+++ b/src/graphql/GraphQLUser.ts
@@ -19,6 +19,7 @@ const cvCtrl: CVActions = new CVActionsImpl()
 export const UserType = new GraphQLObjectType({
   name : 'User',
   fields : {
+    id: { type: GraphQLString },
     profile: { type: UserProfileType },
     permissions: { type: new GraphQLList(GraphQLString) },
     cv: {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -25,6 +25,9 @@ import {
   EventInputType
 } from './GraphQLEvent'
 import {
+  EventCheckInType,
+} from './GraphQLEventCheckIn'
+import {
   FeedbackType,
   FeedbackInputType,
 } from './GraphQLFeedback'
@@ -97,6 +100,17 @@ const schema = new GraphQLSchema({
         type: new GraphQLList(FeedbackType),
         resolve(a, b, { req, res }) {
           return requireAuth(req, res, () => feedbackCtrl.getAllFeedback())
+        },
+      },
+      eventCheckIns: {
+        description: 'Get all check-ins for an event',
+        type: new GraphQLList(EventCheckInType),
+        args: {
+          eventId: { type: new GraphQLNonNull(GraphQLString) },
+        },
+        resolve(a, { eventId }, { req, res }) {
+          return requireAuth(req, res, () =>
+            eventCtrl.getCheckIns(req.user, eventId))
         },
       },
     },
@@ -194,6 +208,30 @@ const schema = new GraphQLSchema({
         resolve(a, { companyId }, { req, res }) {
           return requireAuth(req, res,
             () => feedbackCtrl.removeFeedback(companyId))
+        },
+      },
+      addEventCheckIn: {
+        description: 'Checks in a user at an event',
+        type: EventCheckInType,
+        args: {
+          eventId: { type: new GraphQLNonNull(GraphQLString) },
+          userId: { type: GraphQLString },
+        },
+        resolve(a, { userId, eventId }, { req, res }) {
+          return requireAuth(req, res, () =>
+            eventCtrl.addCheckIn(req.user, eventId, (userId || req.user.id)))
+        },
+      },
+      removeEventCheckIn: {
+        description: 'Removes a checked in user from an event',
+        type: EventCheckInType,
+        args: {
+          eventId: { type: new GraphQLNonNull(GraphQLString) },
+          userId: { type: GraphQLString },
+        },
+        resolve(a, { userId, eventId }, { req, res }) {
+          return requireAuth(req, res, () =>
+            eventCtrl.removeCheckIn(req.user, eventId, (userId || req.user.id)))
         },
       },
     },

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -10,4 +10,11 @@ export interface Event {
   readonly afterSurveys: string[]
   readonly pictures: string[]
   readonly published: boolean
+  checkins: EventCheckIn[]
+}
+
+export interface EventCheckIn {
+  readonly userId: string
+  readonly checkedInAt: Date
+  readonly checkedInById: string
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,7 +1,7 @@
 import { CV, CVSection, createDefaultCV } from './CV'
 import { User, UserProfile, MemberType, Permission } from './User'
 import { Feedback, createDefaultFeedback } from './Feedback'
-import { Event } from './Event'
+import { Event, EventCheckIn } from './Event'
 
 export {
   CV,
@@ -14,4 +14,5 @@ export {
   Feedback,
   createDefaultFeedback,
   Event,
+  EventCheckIn,
 }

--- a/src/mongodb/Event.ts
+++ b/src/mongodb/Event.ts
@@ -17,6 +17,7 @@ const eventSchema: mongoose.Schema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  checkins: [],
 }, { timestamps: true })
 
 export const Event =


### PR DESCRIPTION
This adds check-ins to events. 
I decided to put it in the event model to not have to keep it in sync with events but I think it got kinda messy. Please tell me what you think and help me improve it. Maybe it would be better separated after all?

There's one query for listing all check-ins done for an event. And two mutations for updating (add/remove check-in). 

When a check-in is added, the authenticated user gets set as the one checking the person in. 
A check-in can currently only be removed by the person who checked someone in, or the one being checked in.

