### PR TITLE
Create GraphQL scalar type for dates and use it for events

### DIFF
--- a/src/graphql/GraphQLDateTime.ts
+++ b/src/graphql/GraphQLDateTime.ts
@@ -1,0 +1,16 @@
+import {
+  GraphQLScalarType,
+} from 'graphql'
+
+export const GraphQLDateTime = new GraphQLScalarType({
+  name: 'DateTime',
+  serialize(value) {
+    return value.toJSON()
+  },
+  parseValue(value) {
+    return new Date(value)
+  },
+  parseLiteral(ast: any) {
+    return new Date(ast.value)
+  },
+})

--- a/src/graphql/GraphQLEvent.ts
+++ b/src/graphql/GraphQLEvent.ts
@@ -6,6 +6,7 @@ import {
   GraphQLBoolean,
   GraphQLNonNull,
 } from 'graphql'
+import { GraphQLDateTime } from './GraphQLDateTime'
 
 const MutableEventFields = {
   companyName: { type: GraphQLString },
@@ -13,7 +14,7 @@ const MutableEventFields = {
   location: { type: GraphQLString },
   privateDescription: { type: GraphQLString },
   publicDescription: { type: GraphQLString },
-  date: { type: GraphQLString },
+  date: { type: GraphQLDateTime },
   beforeSurveys: { type: new GraphQLList(GraphQLString) },
   afterSurveys: { type: new GraphQLList(GraphQLString) },
   pictures: { type: new GraphQLList(GraphQLString) },


### PR DESCRIPTION
Had a lot of problems with parsing dates in speedman. 
This adds a graphql scalar type for dealing with dates and serializes them to the ISO8601 format which is simple to parse with a lot of built in support. 

Haven't really tested a lot with the front-end but it seems to work to update dates on events as before. 
The input date is just parsed using `new Date(input)` so that should be the same as before.