### PR TITLE
Differentiate between common pre and post event questions

### DIFF
--- a/src/graphql/GraphQLEventForms.ts
+++ b/src/graphql/GraphQLEventForms.ts
@@ -55,19 +55,16 @@ const CommonFormFields = {
   updatedAt: { type: GraphQLString },
 }
 
-const MutableFormFields = {
-  interestInRegularWork: { type: RatingType },
-  interestInCompanyMotivation: { type: GraphQLString },
-}
-
 const MutablePreEventFormFields = {
-  ...MutableFormFields,
+  interestInRegularWorkBefore: { type: RatingType },
+  interestInCompanyMotivationBefore: { type: GraphQLString },
   familiarWithCompany: { type: FamiliarityType },
   viewOfCompany: { type: GraphQLString },
 }
 
 const MutablePostEventFormFields = {
-  ...MutableFormFields,
+  interestInRegularWork: { type: RatingType },
+  interestInCompanyMotivation: { type: GraphQLString },
   eventImpact: { type: EventImpactType },
   qualifiedToWork: { type: GraphQLBoolean },
   atmosphereRating: { type: RatingType },

--- a/src/models/EventForms.ts
+++ b/src/models/EventForms.ts
@@ -20,16 +20,18 @@ export interface EventForm extends mongoose.Document {
   readonly eventId: string
   readonly createdAt: string
   readonly updatedAt: string
-  readonly interestInRegularWork: Rating
-  readonly interestInCompanyMotivation: string
 }
 
 export interface PreEventForm extends EventForm {
+  readonly interestInRegularWorkBefore: Rating
+  readonly interestInCompanyMotivationBefore: string
   readonly familiarWithCompany: Familiarity
   readonly viewOfCompany: string
 }
 
 export interface PostEventForm extends EventForm {
+  readonly interestInRegularWork: Rating
+  readonly interestInCompanyMotivation: string
   readonly eventImpact: EventImpact
   readonly qualifiedToWork: boolean
   readonly atmosphereRating: Rating

--- a/src/mongodb/EventForms.ts
+++ b/src/mongodb/EventForms.ts
@@ -13,13 +13,13 @@ const preEventFormSchema: mongoose.Schema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  interestInRegularWork: {
+  interestInRegularWorkBefore: {
     type: Number,
     required: true,
     min: 1,
     max: 5,
   },
-  interestInCompanyMotivation: {
+  interestInCompanyMotivationBefore: {
     type: String,
     required: true,
   },


### PR DESCRIPTION
Two questions had the same identifier both for pre and post event, but because I am lazy the easiest way to fix I problem I was having was to change the name. Probably requires some update to apps.