### PR TITLE
Adding endpoint for listing users that have not filled in pre / post event form

### DIFF
--- a/src/controllers/EventFormActions.ts
+++ b/src/controllers/EventFormActions.ts
@@ -13,6 +13,16 @@ export interface EventFormActions {
     eventId: string
   ): Promise<models.EventForm[]> | undefined
 
+  getMissingPreEventFormUsers(
+    user: models.User,
+    eventId: string
+  ): Promise<models.User[] | undefined>
+
+  getMissingPostEventFormUsers(
+    user: models.User,
+    eventId: string
+  ): Promise<models.User[] | undefined>
+
   createPreEventForm(
     user: models.User,
     eventId: string,

--- a/src/controllers/EventFormActionsImpl.ts
+++ b/src/controllers/EventFormActionsImpl.ts
@@ -1,5 +1,6 @@
 import * as mongodbForms from '../mongodb/EventForms'
 import * as mongodbEvent from '../mongodb/Event'
+import * as mongodbUser from '../mongodb/User'
 import * as models from '../models'
 import { EventFormActions } from './EventFormActions'
 
@@ -62,6 +63,54 @@ export class EventFormActionsImpl implements EventFormActions {
         return preForms.concat(postForms)
       })
     })
+  }
+
+  async getMissingPreEventFormUsers(
+    user: models.User,
+    eventId: string
+  ): Promise<models.User[] | undefined> {
+    if (!studsUser(user) && !eventPermission(user)) {
+      return undefined
+    }
+
+    const users: models.User[] = await mongodbUser.User.find(
+      { 'profile.memberType': models.MemberType.StudsMember }
+    ).exec()
+
+    const preEventForms: models.EventForm[] =
+      await mongodbForms.PreEventForm.find(
+        { eventId }
+      ).exec()
+
+    const preEventFormUserIds = preEventForms.map(it => it.userId)
+
+    return users.filter(user =>
+      !preEventFormUserIds.includes(user.id)
+    )
+  }
+
+  async getMissingPostEventFormUsers(
+    user: models.User,
+    eventId: string
+  ): Promise<models.User[] | undefined> {
+    if (!studsUser(user) && !eventPermission(user)) {
+      return undefined
+    }
+
+    const users: models.User[] = await mongodbUser.User.find(
+      { 'profile.memberType': models.MemberType.StudsMember }
+    ).exec()
+
+    const postEventForms: models.EventForm[] =
+      await mongodbForms.PostEventForm.find(
+        { eventId }
+      ).exec()
+
+    const postEventFormUserIds = postEventForms.map(it => it.userId)
+
+    return users.filter(user =>
+      !postEventFormUserIds.includes(user.id)
+    )
   }
 
   createPreEventForm(

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -140,6 +140,28 @@ const schema = new GraphQLSchema({
             () => eventFormCtrl.getAllEventForms(req.user, eventId))
         },
       },
+      missingPreEventFormUsers: {
+        description: descriptions.missingPreEventFormUsersQuery,
+        type: new GraphQLList(UserType),
+        args: {
+          eventId: { type: GraphQLString },
+        },
+        async resolve(root, { eventId }, { req, res }) {
+          return await requireAuth(req, res,
+            () => eventFormCtrl.getMissingPreEventFormUsers(req.user, eventId))
+        },
+      },
+      missingPostEventFormUsers: {
+        description: descriptions.missingPostEventFormUsersQuery,
+        type: new GraphQLList(UserType),
+        args: {
+          eventId: { type: GraphQLString },
+        },
+        async resolve(root, { eventId }, { req, res }) {
+          return await requireAuth(req, res,
+            () => eventFormCtrl.getMissingPostEventFormUsers(req.user, eventId))
+        },
+      },
     },
   }),
   mutation: new GraphQLObjectType({

--- a/src/graphql/schemaDescriptions.ts
+++ b/src/graphql/schemaDescriptions.ts
@@ -4,6 +4,10 @@ export const eventFormsQuery = 'Returns the event forms that match the ' +
   'allowed to fetch event forms of another userId.'
 export const allEventFormsQuery = 'Returns all event forms for a certain ' +
   'event.'
+export const missingPreEventFormUsersQuery = 'Returns all users that has not ' +
+  'currently filled in the pre event forms for the provided event.'
+export const missingPostEventFormUsersQuery = 'Returns all users that has ' +
+  'not currently filled in the post event forms for the provided event.'
 export const createPreEventFormMutation = 'Creates a new pre event form ' +
   'for the specified event'
 export const createPostEventFormMutation = 'Creates a new post event form ' +


### PR DESCRIPTION
Example query: 

```
query {
  missingPostEventFormUsers(eventId: "5c5ee8035d53a53b26b7d93f") {
    profile {
      firstName
      lastName
    }
  }
}
```

Returns:

```
{
  "data": {
    "missingPostEventFormUsers": [
      {
        "profile": {
          "firstName": "ExampleFirstname",
          "lastName": "ExampleLastname"
        }
      }
    ]
  }
}
```

Same for `missingPreEventFormUsers`. The code should be fairly clear, but let me know otherwise. 

A bit :sleeping: so please have an extra lookout for :bug: or :thinking: when reviewing :heart:  