### PR TITLE
Fn/fix happening geojson overwrite

### DIFF
--- a/__tests__/happening.mutation.test.ts
+++ b/__tests__/happening.mutation.test.ts
@@ -1,7 +1,7 @@
 const supertest = require("supertest")
 import { app } from '../src/server'
 import { mockDatabase, closeDatabase } from './utillity/mockDatabase'
-import { createHappeningMutation, updateHappeningMutation } from './utillity/happeningQueries'
+import { createHappeningMutation, updateHappeningMutation, updateLocationMutation } from './utillity/happeningQueries'
 
 let server: any
 let request: any
@@ -101,6 +101,39 @@ describe('happeningUpdate', () => {
                 expect(res.body.data.happeningUpdate.participants).toBeInstanceOf(Array)
                 expect(res.body.data.happeningUpdate.participants[0]).toBeInstanceOf(Object)
                 expect(res.body.data.happeningUpdate.participants[0].id).toBe('000000000000000000000002')
+                return done()
+            })
+    })
+
+    it('updates location object without overwriting data', async (done) => {
+        request
+            .post("/graphql")
+            .send({
+                query: updateLocationMutation
+            })
+            .set("Accept", "application/json")
+            .set('credentials', 'include')
+            .set('Authorization', `Bearer ${token}`)
+            .expect("Content-Type", /json/)
+            .expect(200)
+            .end((err: any, res: any) => {
+                if(err){
+                    console.log(res.error)
+                    return done(err)
+                }
+                
+                expect(res.body).toBeInstanceOf(Object)
+                expect(res.body.data.happeningUpdate).toBeInstanceOf(Object)
+                expect(res.body.data.happeningUpdate.id).toBe('700000000000000000000001')
+                expect(res.body.data.happeningUpdate.description).toBe('This is a Very Fun Happening Description')
+                expect(res.body.data.happeningUpdate.location).toBeInstanceOf(Object)
+                expect(res.body.data.happeningUpdate.location.type).toBe('Feature')
+                expect(res.body.data.happeningUpdate.location.geometry).toBeInstanceOf(Object)
+                expect(res.body.data.happeningUpdate.location.geometry.type).toBe('Point')
+                expect(res.body.data.happeningUpdate.location.geometry.coordinates).toBeInstanceOf(Array)
+                expect(res.body.data.happeningUpdate.location.geometry.coordinates).toEqual([125.6, 10.1])
+                expect(res.body.data.happeningUpdate.location.properties).toBeInstanceOf(Object)
+                expect(res.body.data.happeningUpdate.location.properties.name).toBe('New name of location')
                 return done()
             })
     })

--- a/__tests__/utillity/happeningQueries.ts
+++ b/__tests__/utillity/happeningQueries.ts
@@ -60,3 +60,27 @@ mutation {
         }
     }
 }`
+
+export const updateLocationMutation = `
+mutation { 
+    happeningUpdate(id: "700000000000000000000001", fields: {
+        location: {
+            properties: {
+                name: "New name of location"
+            }
+        }
+    }) {
+        id
+        description
+        location {
+            type
+            geometry {
+                type
+                coordinates
+            }
+            properties {
+                name
+            }
+        }
+    }
+}`

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
     "express-validator": "5.3.1",
+    "flat": "^5.0.2",
     "graphiql": "^1.2.0",
     "graphql": "^15.4.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/controllers/HappeningActionsImpl.ts
+++ b/src/controllers/HappeningActionsImpl.ts
@@ -1,4 +1,5 @@
 import * as mongodb from '../mongodb/Happening'
+import * as flatten from 'flat'
 import { HappeningActions } from './HappeningActions'
 import { Happening } from '../models'
 import { CreateHappening } from '../models/Happening'
@@ -29,7 +30,7 @@ export class HappeningActionsImpl implements HappeningActions {
     updateHappening(id: string, fields: Partial<Happening>): Promise<Happening> {
         return mongodb.Happening.findOneAndUpdate(
             { _id: id },
-            { ...fields },
+            { ...flatten(fields) },
             { new: true }
         )
             .populate('host')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,6 +2282,11 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Fixar så att det går att uppdatera enskilda fält (t.ex. bara namnet) på en plats i en happening utan att allt annat i GEOJSON-objektet skrivs över i databasen.